### PR TITLE
Support test notifications which implemented in Graylog3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-teams</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <graylog.version>3.1.0</graylog.version>
+        <graylog.version>3.1.3</graylog.version>
 
         <!-- Plugins will not be deployed by default - set to `false` if you actually want to deploy it -->
         <maven.source.skip>true</maven.source.skip>

--- a/src/main/java/org/graylog/plugins/teams/event/notifications/TeamsEventNotification.java
+++ b/src/main/java/org/graylog/plugins/teams/event/notifications/TeamsEventNotification.java
@@ -14,6 +14,7 @@ import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.plugins.teams.client.TeamsClient;
 import org.graylog.plugins.teams.client.TeamsClientException;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.plugin.MessageSummary;
 
@@ -54,13 +55,14 @@ public class TeamsEventNotification implements EventNotification {
 
   private Map<String, Object> getModel(final EventNotificationContext ctx, final ImmutableList<MessageSummary> backlog) {
     final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+    final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
     final EventNotificationModelData modelData = EventNotificationModelData.builder()
         .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
         .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
         .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
         .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-        .jobDefinitionId(ctx.jobTrigger().jobDefinitionId())
-        .jobTriggerId(ctx.jobTrigger().id())
+        .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+        .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
         .event(ctx.event())
         .backlog(backlog)
         .build();


### PR DESCRIPTION
## Related Issue
fixes #12 and #11 

## PR Description
As of Graylog3.1.3, it started providing test notification but `teams-plugin` does not work with that function.
This PR fixes the problem to support test notification.
