### PR TITLE
Remove relative path to parent project reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
         <version>3.1.3</version>
-        <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <groupId>org.graylog.plugins</groupId>


### PR DESCRIPTION
## Related Issues
close https://github.com/hidapple/graylog-plugin-teams/issues/31

## Description
Parent project should not be referred as relative path