### PR TITLE
Possibility to clickthrough directly into graylog msg

### DIFF
--- a/src/main/java/org/graylog/plugins/teams/client/TeamsClient.java
+++ b/src/main/java/org/graylog/plugins/teams/client/TeamsClient.java
@@ -36,7 +36,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.graylog.plugins.teams.event.notifications.TeamsEventNotificationConfig;
-import org.graylog2.plugin.MessageSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/graylog/plugins/teams/client/TeamsClient.java
+++ b/src/main/java/org/graylog/plugins/teams/client/TeamsClient.java
@@ -24,6 +24,8 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -34,6 +36,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.graylog.plugins.teams.event.notifications.TeamsEventNotificationConfig;
+import org.graylog2.plugin.MessageSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +70,7 @@ public class TeamsClient {
         .url(url)
         .post(reqBody)
         .build();
-    LOG.debug("Request: " + req.toString());
+    LOG.debug("Request: " + req);
 
     // Response
     try (final Response res = client.newCall(req).execute()) {
@@ -81,12 +84,23 @@ public class TeamsClient {
   }
 
   private TeamsMessageCard createRequest(final TeamsEventNotificationConfig config, final Map<String, Object> model) {
+    final List<String> graylogMsgUrls = new ArrayList<>();
+    final Object backlog = model.get("backlog");
+    final String graylogUrl = config.graylogURL().endsWith("/") ? config.graylogURL() : config.graylogURL() + "/";
+    if (backlog instanceof List) {
+      for (final Map<String, Object> msgSummary : (List<Map<String, Object>>) backlog) {
+        graylogMsgUrls.add(graylogUrl + "messages/" + msgSummary.get("index") + "/" + msgSummary.get("id"));
+      }
+    } else {
+      graylogMsgUrls.add(graylogUrl);
+    }
+
     return new TeamsMessageCard(
         config.color(),
         "Graylog Event Notification is triggered",
         "Event: " + model.get("event_definition_title"),
-        buildMessage(config, model),
-        config.graylogURL()
+        buildMessage(config.message(), model),
+        graylogMsgUrls
     );
   }
 
@@ -99,12 +113,12 @@ public class TeamsClient {
     }
   }
 
-  private String buildMessage(final TeamsEventNotificationConfig config, final Map<String, Object> model) {
+  private String buildMessage(final String textTemplate, final Map<String, Object> model) {
     final String template;
-    if (Strings.isNullOrEmpty(config.message())) {
+    if (Strings.isNullOrEmpty(textTemplate)) {
       template = TeamsEventNotificationConfig.DEFAULT_MESSAGE;
     } else {
-      template = config.message();
+      template = textTemplate;
     }
     return templateEngine.transform(template, model);
   }

--- a/src/main/java/org/graylog/plugins/teams/client/TeamsMessageCard.java
+++ b/src/main/java/org/graylog/plugins/teams/client/TeamsMessageCard.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,15 +39,17 @@ import java.util.Objects;
  */
 public class TeamsMessageCard {
 
-  private String type;
-  private String context;
-  private String themeColor;
-  private String title;
-  private String text;
+  private static final int POTENTIAL_ACTIONS_LIMIT = 3;
+
+  private final String type;
+  private final String context;
+  private final String themeColor;
+  private final String title;
+  private final String text;
   private List<Section> sections;
   private List<PotentialAction> potentialAction;
 
-  public TeamsMessageCard(String color, String title, String text, String detailMsg, String url) {
+  public TeamsMessageCard(String color, String title, String text, String detailMsg, List<String> urls) {
     this.type = "MessageCard";
     this.context = "https://schema.org/extensions";
     this.themeColor = color;
@@ -55,12 +58,18 @@ public class TeamsMessageCard {
     if (!StringUtils.isEmpty(detailMsg)) {
       this.sections = Lists.newArrayList(new Section("Detail Message:", detailMsg));
     }
-    if (!StringUtils.isEmpty(url)) {
-      Map<String, String> target = new HashMap<>();
-      target.put("os", "default");
-      target.put("uri", url);
-      this.potentialAction = Lists.newArrayList(
-          new PotentialAction("OpenUri", "Open Graylog", Lists.newArrayList(target)));
+
+    if (!urls.isEmpty()) {
+      this.potentialAction = new ArrayList<>();
+      final int numberOfPotentialActions = Math.min(urls.size(), POTENTIAL_ACTIONS_LIMIT);
+      for (int i = 1; i <= numberOfPotentialActions; i++) {
+        final Map<String, String> target = new HashMap<>();
+        target.put("os", "default");
+        target.put("uri", urls.get(0));
+
+        this.potentialAction.add(
+            new PotentialAction("OpenUri", numberOfPotentialActions > 1 ? "Open Graylog - message " + i : "Open Graylog", Lists.newArrayList(target)));
+      }
     }
   }
 

--- a/src/test/java/org/graylog/plugins/teams/client/TeamsMessageCardTest.java
+++ b/src/test/java/org/graylog/plugins/teams/client/TeamsMessageCardTest.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.ArrayList;
+
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +32,7 @@ class TeamsMessageCardTest {
 
   @Test
   void toJsonString_WithoutDetailMsgAndGraylogURL() throws IOException {
-    TeamsMessageCard sut = new TeamsMessageCard("0076D7", "Title", "Text", StringUtils.EMPTY, StringUtils.EMPTY);
+    TeamsMessageCard sut = new TeamsMessageCard("0076D7", "Title", "Text", StringUtils.EMPTY, new ArrayList<>());
     String expected = "{"
         + "\"@type\":\"MessageCard\","
         + "\"@context\":\"https://schema.org/extensions\","
@@ -47,7 +50,8 @@ class TeamsMessageCardTest {
 
   @Test
   void toJsonString_WithGraylogURL() throws IOException {
-    TeamsMessageCard sut = new TeamsMessageCard("0076D7", "Title", "Text", StringUtils.EMPTY, "http://localhost:9000");
+    TeamsMessageCard sut = new TeamsMessageCard("0076D7", "Title", "Text", StringUtils.EMPTY,
+        Lists.newArrayList("http://localhost:9000/messages/index/id"));
     String expected = "{"
         + "\"@type\":\"MessageCard\","
         + "\"@context\":\"https://schema.org/extensions\","
@@ -56,10 +60,10 @@ class TeamsMessageCardTest {
         + "\"text\":\"Text\","
         + "\"potentialAction\":[{"
         + "\"@type\":\"OpenUri\","
-        + "\"name\":\"Open Graylog\","
+        + "\"name\":\"Open Graylog - message 1\","
         + "\"targets\":[{"
         + "\"os\":\"default\","
-        + "\"uri\":\"http://localhost:9000\""
+        + "\"uri\":\"http://localhost:9000/messages/index/id\""
         + "}]"
         + "}]"
         + "}";

--- a/src/test/java/org/graylog/plugins/teams/client/TeamsMessageCardTest.java
+++ b/src/test/java/org/graylog/plugins/teams/client/TeamsMessageCardTest.java
@@ -60,7 +60,7 @@ class TeamsMessageCardTest {
         + "\"text\":\"Text\","
         + "\"potentialAction\":[{"
         + "\"@type\":\"OpenUri\","
-        + "\"name\":\"Open Graylog - message 1\","
+        + "\"name\":\"Open Graylog\","
         + "\"targets\":[{"
         + "\"os\":\"default\","
         + "\"uri\":\"http://localhost:9000/messages/index/id\""


### PR DESCRIPTION
## Related Issues
#200

## Description
Potential action now links directly to backlog message. If no backlog message is available, then the button will link to Graylog URL. The Graylog URL entered in Plugin GUI does not change - it is used to construct message link. There is a static limit (set to 3) to number of potential actions, since size of backlog can be big.

## Screenshot (if any)
none