### PR TITLE
new snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>graylog-plugin-teams</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>


### PR DESCRIPTION
Hi @hidapple , I cannot use Maven release plugin - I do not have rights to create tags + push to main (from the plugin). If you want me to release in the future please consider to grant me these rights. Thanks

I already created `2.1.0` release manually via Github UI (that's the only option for me now), see https://github.com/hidapple/graylog-plugin-teams/releases/tag/2.1.0